### PR TITLE
Fix placeholder display issue with non-text content

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -118,7 +118,7 @@ RE.setPlaceholderText = function(text) {
 };
 
 RE.updatePlaceholder = function() {
-    if (RE.editor.textContent.length > 0) {
+    if (RE.editor.innerHTML.indexOf('img') !== -1 || (RE.editor.textContent.length > 0 && RE.editor.innerHTML.length > 0)) {
         RE.editor.classList.remove("placeholder");
     } else {
         RE.editor.classList.add("placeholder");


### PR DESCRIPTION
## Overview
When the editor contains non-text content such as images, the placeholder still shows. This PR fixes the issue by adding conditions to check for non-text content.

See issues https://github.com/cjwirth/RichEditorView/issues/117 & https://github.com/cjwirth/RichEditorView/issues/91